### PR TITLE
Add `infected` trait

### DIFF
--- a/src/corn-model.ts
+++ b/src/corn-model.ts
@@ -1,6 +1,6 @@
 import * as Populations from './populations';
-import { IAgent, IEnvironment, IInteractive, ISpecies } from './populations-types';
-const { Models: { Agents: { BasicPlant }, Environment, Rule, Species },
+import { IAgent, IEnvironment, IInteractive, ISpecies, ITrait } from './populations-types';
+const { Models: { Agents: { BasicPlant }, Environment, Rule, Species, Trait },
         UI: { Interactive } } = Populations;
 
 declare const gImages: {[key: string]: string};
@@ -16,6 +16,14 @@ const env: IEnvironment = new Environment({
 
 const maturity = 250;
 
+const cornInfectedTrait: ITrait = new Trait({
+                                        name: 'infected',
+                                        possibleValues: [ true, false ],
+                                        default: false,
+                                        float: false,
+                                        mutatable: false
+                                      });
+
 const corn: ISpecies = new Species({
   speciesName: "Corn",
   agentClass: BasicPlant,
@@ -24,7 +32,7 @@ const corn: ISpecies = new Species({
     SPROUT_AGE: 10,
     MATURITY_AGE: maturity
   },
-  traits: [],
+  traits: [cornInfectedTrait],
   imageRules: [
     {
       name: 'corn',

--- a/src/populations-types.d.ts
+++ b/src/populations-types.d.ts
@@ -125,12 +125,12 @@ export class IEnvironment {
 export class ITrait {
     constructor(traitDesc: {
         name: string,
-        possibleValues: any,
-        min: number,
-        max: number,
+        possibleValues?: any,
+        min?: number,
+        max?: number,
         default: any,
-        float: boolean,
-        mutatable: boolean
+        float?: boolean,
+        mutatable?: boolean
     });
 
     getDefaultValue(): any;


### PR DESCRIPTION
- [#157365271] fixes bug in which exception is thrown when adding corn while simulation is running

Fixes bug found by @lbondaryk and mentioned in standup this morning.