### PR TITLE
Worms prefer trap crop to corn

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,10 @@ interface IAppProps {
 
 interface IAppState {
   initialCorn: number;
+  initialTrap: number;
   initialWorms: number;
   totalCorn: number;
+  totalTrap: number;
   totalWorm: number;
   infectedCorn: number;
   harvestCorn: number;
@@ -22,8 +24,10 @@ class App extends React.Component<IAppProps, IAppState> {
 
   public state: IAppState = {
     initialCorn: 0,
+    initialTrap: 0,
     initialWorms: 0,
     totalCorn: 0,
+    totalTrap: 0,
     totalWorm: 0,
     infectedCorn: 0,
     harvestCorn: 0,
@@ -34,14 +38,16 @@ class App extends React.Component<IAppProps, IAppState> {
     initCornModel(this.props.simulationElt, {});
 
     Events.addEventListener(Environment.EVENTS.STEP, (evt: any) => {
-      const { countCorn, countWorm, infected, simulationDay } = getCornStats();
+      const { countCorn, countTrap, countWorm, infected, simulationDay } = getCornStats();
       const actualDay = Math.trunc(simulationDay / 3);
-      this.setState({ totalCorn: countCorn, totalWorm: countWorm, infectedCorn: infected, simulationDay: actualDay });
+      this.setState({ totalCorn: countCorn, totalTrap: countTrap,
+                      totalWorm: countWorm, infectedCorn: infected, simulationDay: actualDay });
     });
 
     Events.addEventListener(Environment.EVENTS.START, (evt: any) => {
-      const { countCorn, countWorm, infected } = getCornStats();
-      this.setState({ initialCorn: countCorn, initialWorms: countWorm, infectedCorn: infected });
+      const { countCorn, countTrap, countWorm, infected } = getCornStats();
+      this.setState({ initialCorn: countCorn, initialTrap: countTrap,
+                      initialWorms: countWorm, infectedCorn: infected });
     });
   }
 
@@ -55,10 +61,6 @@ class App extends React.Component<IAppProps, IAppState> {
           Plant Corn Sparsely
         </button>
         <br />
-        <button id="add-worms-sparse" onClick={addWormsSparse}>
-          Add Worms
-        </button>
-        <br/>
         <button id="add-trap-dense" onClick={addTrapCropDense}>
           Plant Trap Crop Densely
         </button>
@@ -66,11 +68,17 @@ class App extends React.Component<IAppProps, IAppState> {
           Plant Trap Crop Sparsely
         </button>
         <br/>
+        <button id="add-worms-sparse" onClick={addWormsSparse}>
+          Add Worms
+        </button>
+        <br/>
         <div style={{ margin: 5, padding: 5, border: '1px solid' }}>
-          Day: <span id="infected">{this.state.simulationDay}</span><br />
-          Corn planted: <span id="infected">{this.state.initialCorn}</span><br />
-          Corn remaining:<span id="infected">{this.state.totalCorn}</span><br />
-          Worms: <span id="infected">{this.state.totalWorm}</span><br />
+          Day: <span>{this.state.simulationDay}</span><br />
+          Corn planted: <span>{this.state.initialCorn}</span><br />
+          Corn remaining: <span>{this.state.totalCorn}</span><br />
+          Trap planted: <span>{this.state.initialTrap}</span><br />
+          Trap remaining: <span>{this.state.totalTrap}</span><br />
+          Worms: <span>{this.state.totalWorm}</span><br />
         </div>
       </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ interface IAppState {
   initialCorn: number;
   initialTrap: number;
   initialWorms: number;
+  dayFirstCornEaten: number | null;
   totalCorn: number;
   totalTrap: number;
   totalWorm: number;
@@ -26,6 +27,7 @@ class App extends React.Component<IAppProps, IAppState> {
     initialCorn: 0,
     initialTrap: 0,
     initialWorms: 0,
+    dayFirstCornEaten: null,
     totalCorn: 0,
     totalTrap: 0,
     totalWorm: 0,
@@ -38,16 +40,20 @@ class App extends React.Component<IAppProps, IAppState> {
     initCornModel(this.props.simulationElt, {});
 
     Events.addEventListener(Environment.EVENTS.STEP, (evt: any) => {
+      let { dayFirstCornEaten } = this.state;
       const { countCorn, countTrap, countWorm, infected, simulationDay } = getCornStats();
       const actualDay = Math.trunc(simulationDay / 3);
-      this.setState({ totalCorn: countCorn, totalTrap: countTrap,
-                      totalWorm: countWorm, infectedCorn: infected, simulationDay: actualDay });
+      if ((this.state.dayFirstCornEaten == null) && (countCorn < this.state.initialCorn)) {
+        dayFirstCornEaten = actualDay;
+      }
+      this.setState({ totalCorn: countCorn, totalTrap: countTrap, totalWorm: countWorm, 
+                      dayFirstCornEaten, infectedCorn: infected, simulationDay: actualDay });
     });
 
     Events.addEventListener(Environment.EVENTS.START, (evt: any) => {
       const { countCorn, countTrap, countWorm, infected } = getCornStats();
-      this.setState({ initialCorn: countCorn, initialTrap: countTrap,
-                      initialWorms: countWorm, infectedCorn: infected });
+      this.setState({ initialCorn: countCorn, initialTrap: countTrap, initialWorms: countWorm, 
+                      dayFirstCornEaten: null, infectedCorn: infected });
     });
   }
 
@@ -76,6 +82,7 @@ class App extends React.Component<IAppProps, IAppState> {
           Day: <span>{this.state.simulationDay}</span><br />
           Corn planted: <span>{this.state.initialCorn}</span><br />
           Corn remaining: <span>{this.state.totalCorn}</span><br />
+          First corn eaten: <span>{this.state.dayFirstCornEaten}</span><br />
           Trap planted: <span>{this.state.initialTrap}</span><br />
           Trap remaining: <span>{this.state.totalTrap}</span><br />
           Worms: <span>{this.state.totalWorm}</span><br />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,12 @@ class App extends React.Component<IAppProps, IAppState> {
       this.setState({ initialCorn: countCorn, initialTrap: countTrap, initialWorms: countWorm, 
                       dayFirstCornEaten: null, infectedCorn: infected });
     });
+
+    Events.addEventListener(Environment.EVENTS.RESET, (evt: any) => {
+      this.setState({ initialCorn: 0, initialTrap: 0, initialWorms: 0,
+                      totalCorn: 0, totalTrap: 0, totalWorm: 0,
+                      dayFirstCornEaten: null, infectedCorn: 0, simulationDay: 0 });
+    });
   }
 
   public render() {

--- a/src/corn-model.ts
+++ b/src/corn-model.ts
@@ -95,6 +95,7 @@ const agentIsCorn = (envAgent: Agent) => {
 
 export function getCornStats() {
   let countCorn = 0,
+    countTrap = 0,
     countWorm = 0,
     infected = 0;
   const simulationDay = env.date;
@@ -104,11 +105,15 @@ export function getCornStats() {
       if (a.get('health') < 100) {
         ++ infected;
       }
-    } else {
+    } 
+    else if (a.species.speciesName === 'Trap') {
+      ++ countTrap;
+    }
+    else if (a.species.speciesName === 'Worm') {
       ++countWorm;
     }
   });
-  return { countCorn, countWorm, infected, simulationDay };
+  return { countCorn, countTrap, countWorm, infected, simulationDay };
 }
 
 export interface IModelParams {

--- a/src/populations.d.ts
+++ b/src/populations.d.ts
@@ -82,7 +82,7 @@ declare namespace Populations {
       WANDERING: string
     };
 
-    constructor(args:any);
+    constructor(args: any);
 
     makeNewBorn(): void;
 
@@ -154,7 +154,16 @@ declare namespace Populations {
     season: string;
     date: number;
   
-    static EVENTS: { [index: string]: string };
+    static EVENTS: {
+      START: string,
+      STOP: string,
+      STEP: string,
+      RESET: string,
+      AGENT_ADDED: string,
+      AGENT_EATEN: string,
+      SEASON_CHANGED: string,
+      USER_REMOVED_AGENTS: string
+    };
   
     constructor(opts: any);
   

--- a/src/species/varied-plants.ts
+++ b/src/species/varied-plants.ts
@@ -4,8 +4,17 @@ const kPlantScale = 0.1;
 const kFlowerAnchorX = 0;
 const kFlowerAnchorY = -30;
 
+const trapHealthTrait = new Trait({
+  name: 'health',
+  min: 0,
+  max: 100,
+  default: 100,
+  float: false,
+  mutatable: false
+});
+
 export const variedPlants: Species = new Species({
-  speciesName: "varied plants",
+  speciesName: "Trap",
   agentClass: BasicPlant,
   defs: {
     MAX_AGE: 10000,
@@ -22,6 +31,7 @@ export const variedPlants: Species = new Species({
     }
   },
   traits: [
+    trapHealthTrait,
     new Trait({ name: "size", min: 1, max: 10, mutatable: true }),
     new Trait({ name: "root size", min: 1, max: 10, mutatable: true })
   ],


### PR DESCRIPTION
[#157444138] Implement prey preference mechanism so worms preferentially eat trap crop rather than corn

Also, add trop plant stats to feedback area and clear the feedback area when the reset button is pressed.

@dstrawberrygirl This PR depends on the previous PR. It will be easier to review/merge this PR after merging the previous PR. If you let me know when the previous one is merged I can rebase this one to make for a cleaner history.