### PR TITLE
Timeline improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ interface IAppProps {
 
 interface IAppState {
   interactive?: Interactive;
+  year: number;
   simulationState: ISimulationState;
   // store as strings during editing
   wormEatingDistance: string;
@@ -80,6 +81,7 @@ interface IAppState {
 class App extends React.Component<IAppProps, IAppState> {
 
   public state: IAppState = {
+    year: 0,
     simulationState: kNullSimulationState,
     wormEatingDistance: "",
     wormEnergy: "",
@@ -103,11 +105,15 @@ class App extends React.Component<IAppProps, IAppState> {
       this.setState(traitState as any);
     });
 
+    Events.addEventListener(Environment.EVENTS.START, (evt: any) => {
+      this.setState({ simulationState: getCornStats() });
+    });
+
     Events.addEventListener(Environment.EVENTS.STEP, (evt: any) => {
       this.setState({ simulationState: getCornStats() });
     });
 
-    Events.addEventListener(Environment.EVENTS.START, (evt: any) => {
+    Events.addEventListener(Environment.EVENTS.STOP, (evt: any) => {
       this.setState({ simulationState: getCornStats() });
     });
 
@@ -177,6 +183,7 @@ class App extends React.Component<IAppProps, IAppState> {
     return (
       <div className="app">
         <PopulationsModelPanel hideModel={this.props.hideModel}
+                                year={this.state.year}
                                 simulationStep={simulationStep}
                                 interactive={interactive}
                                 onSetInteractive={this.handleSetInteractive}/>
@@ -258,7 +265,7 @@ class App extends React.Component<IAppProps, IAppState> {
               </div>
             </div>
           </div>
-          <SimulationStatistics simulationState={simulationState}/>
+          <SimulationStatistics year={this.state.year} simulationState={simulationState}/>
         </div>
         <Attribution />
       </div>

--- a/src/components/populations-model-panel.tsx
+++ b/src/components/populations-model-panel.tsx
@@ -7,6 +7,7 @@ const SEASONS = ["spring", "summer", "fall", "winter"];
 
 interface IProps {
   hideModel?: boolean;
+  year: number;
   simulationStep: number;
   interactive?: Interactive;
   onSetInteractive: (interactive: Interactive) => void;
@@ -27,12 +28,12 @@ export default class PopulationsModelPanel extends React.Component<IProps, IStat
                                   onSetInteractive={onSetInteractive} />
                               : null,
           // env = interactive && interactive.environment,
-          seasonLengths = [150, 150, 150, 150]; // env && env.seasonLengths;
+          seasonLengths = [200, 200, 200]; // env && env.seasonLengths;
     return (
       <div className="populations-model-panel">
         {populationsModel}
         <TimelineView seasons={SEASONS} seasonLengths={seasonLengths}
-                      simulationStep={simulationStep} />
+                      year={this.props.year} simulationStep={simulationStep} />
       </div>
     );
   }

--- a/src/components/simulation-statistics.tsx
+++ b/src/components/simulation-statistics.tsx
@@ -3,6 +3,7 @@ import '../style/App.css';
 import { ISimulationState } from '../corn-model';
 
 interface IProps {
+  year: number;
   simulationState: ISimulationState;
 }
 

--- a/src/components/timeline-bar.tsx
+++ b/src/components/timeline-bar.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import sizeMe from 'react-sizeme';
+import { sum } from 'lodash';
+
+interface IProps extends ISizeMeProps {
+  seasons?: string[];
+  seasonLengths?: number[];
+  simulationStep: number;
+}
+
+interface IState {}
+
+class TimelineBar extends React.Component<IProps, IState> {
+
+  state: IState = {
+  };
+
+  render() {
+    let cumulativeLength = 0;
+    const { size } = this.props,
+          width = size && size.width || undefined,
+          height = size && size.height || undefined,
+          { seasons, seasonLengths, simulationStep } = this.props,
+          yearLength = seasonLengths ? sum(seasonLengths) : 0,
+          cumulativeLengths = seasonLengths && seasonLengths.map((length) => {
+                                                cumulativeLength += length;
+                                                return cumulativeLength;
+                                              }),
+          seasonTicks = cumulativeLengths
+                          ? cumulativeLengths.map((length, index) => {
+                              const x = width && (length / yearLength) * width;
+                              return <rect key={index} x={x} width={0.1} height={height} stroke="gray" fill="gray"/>;
+                            })
+                          : 0,
+          seasonLabels = cumulativeLengths
+                          ? cumulativeLengths.map((length, index) => {
+                              const prevLength = index > 0 ? cumulativeLengths[index-1] : 0,
+                                    x = width && (0.5 * (prevLength + length) / yearLength) * width;
+                              return <text key={index} style={{textAnchor: 'middle'}} x={x} y={16} fill="black">
+                                      {seasons && seasons[index]}
+                                     </text>;
+                            })
+                          : 0,
+          xCurrent = (simulationStep  / yearLength) * (width || 0);
+    return (
+      <div className="timeline-bar">
+        <svg width={width} height={height} >
+          <rect width={width} height={height} stroke="black" strokeWidth={2} fill="transparent"/>
+          {seasonTicks}
+          {seasonLabels}
+          <rect width={xCurrent} height={height} stroke="gray" fill="gray" opacity={0.5} />
+        </svg>
+      </div>
+    );
+  }
+}
+
+const sizeMeConfig = { monitorWidth: true, monitorHeight: true, noPlaceholder: true };
+export default sizeMe(sizeMeConfig)(TimelineBar as any);

--- a/src/components/timeline-view.tsx
+++ b/src/components/timeline-view.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import sizeMe from 'react-sizeme';
-import { sum } from 'lodash';
+import TimelineBar from './timeline-bar';
+import '../style/timeline-view.css';
 
 interface IProps extends ISizeMeProps {
+  year: number;
   seasons?: string[];
   seasonLengths?: number[];
   simulationStep: number;
@@ -10,49 +11,20 @@ interface IProps extends ISizeMeProps {
 
 interface IState {}
 
-class TimelineView extends React.Component<IProps, IState> {
+export default class TimelineView extends React.Component<IProps, IState> {
 
   state: IState = {
   };
 
   render() {
-    let cumulativeLength = 0;
-    const width = this.props.size.width || undefined,
-          height = this.props.size.height || undefined,
-          { seasons, seasonLengths, simulationStep } = this.props,
-          yearLength = seasonLengths ? sum(seasonLengths) : 0,
-          cumulativeLengths = seasonLengths && seasonLengths.map((length) => {
-                                                cumulativeLength += length;
-                                                return cumulativeLength;
-                                              }),
-          seasonTicks = cumulativeLengths
-                          ? cumulativeLengths.map((length, index) => {
-                              const x = width && (length / yearLength) * width;
-                              return <rect key={index} x={x} width={0.1} height={height} stroke="gray" fill="gray"/>;
-                            })
-                          : 0,
-          seasonLabels = cumulativeLengths
-                          ? cumulativeLengths.map((length, index) => {
-                              const prevLength = index > 0 ? cumulativeLengths[index-1] : 0,
-                                    x = width && (0.5 * (prevLength + length) / yearLength) * width;
-                              return <text key={index} style={{textAnchor: 'middle'}} x={x} y={16} fill="gray">
-                                      {seasons && seasons[index]}
-                                     </text>;
-                            })
-                          : 0,
-          xCurrent = (simulationStep  / yearLength) * (width || 0);
+    const { seasons, seasonLengths, simulationStep } = this.props,
+          year = this.props.year != null ? this.props.year + 1 : 1,
+          yearLabel = `Year ${year}`;
     return (
       <div className="timeline-view">
-        <svg width={width} height={height} >
-          <rect width={width} height={height} stroke="gray" strokeWidth={2} fill="transparent"/>
-          {seasonTicks}
-          {seasonLabels}
-          <rect x={xCurrent} width={1} height={height} stroke="gray" fill="gray"/>
-        </svg>
+        <span className='year-label'>{yearLabel}</span>
+        <TimelineBar seasons={seasons} seasonLengths={seasonLengths} simulationStep={simulationStep} />
       </div>
     );
   }
 }
-
-const sizeMeConfig = { monitorWidth: true, monitorHeight: true, noPlaceholder: true };
-export default sizeMe(sizeMeConfig)(TimelineView as any);

--- a/src/corn-model.ts
+++ b/src/corn-model.ts
@@ -169,6 +169,10 @@ export function initCornModel(simulationElt: HTMLElement | null, params?: IModel
   }));
 
   // limit growing season length - at the end of a year, the remaining corn is harvested
+  // NOTE: since rules are executed in the context of agents, this rule is not applied
+  // when there are no agents, and so the simulation runs forever. A simulation with
+  // no agents is unlikely to be useful, so it doesn't generally come up in practice,
+  // bit it can arise if all of the agents die, for instance.
   env.addRule(new Rule({
     test() {
       return env.date >= 600;

--- a/src/style/App.css
+++ b/src/style/App.css
@@ -2,13 +2,6 @@
   display: flex;
 }
 
-.timeline-view {
-  /* border: 1px solid gray; */
-  height: 22px;
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
 .ui {
   font-size: 0.8em;
   max-width: 300px;

--- a/src/style/timeline-view.css
+++ b/src/style/timeline-view.css
@@ -1,0 +1,17 @@
+.timeline-view {
+  display: flex;
+  flex-direction: row;
+  margin-left: 14px;
+  margin-right: 10px;
+  height: 22px;
+}
+
+.timeline-view .year-label {
+  flex: none;
+  margin-top: 2px;
+  width: 60px;
+}
+
+.timeline-view .timeline-bar {
+  flex: auto;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,7 +3,7 @@
 declare module "react-sizeme";
 // usage: interface IComponentProps extends ISizeMeProps
 interface ISizeMeProps {
-  size: {
+  size?: {
     width: number | null;
     height: number | null;
   }


### PR DESCRIPTION
Timeline improvements [#157640803][#157641152]
- show only three seasons (eliminate winter)
- show bar filling up rather than moving line
- show year to left of bar

@dstrawberrygirl The diffs for `timeline-view.tsx` will make more sense if you consider that `timeline-view.tsx` became `timeline-bar.tsx` and the new `timeline-view.tsx` is a wrapper which contains a `TimelineBar`.