### PR TITLE
Simulation years and worm lifecycle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,6 @@ interface IAppProps {
 
 interface IAppState {
   interactive?: Interactive;
-  year: number;
   simulationState: ISimulationState;
   // store as strings during editing
   wormEatingDistance: string;
@@ -81,7 +80,6 @@ interface IAppState {
 class App extends React.Component<IAppProps, IAppState> {
 
   public state: IAppState = {
-    year: 0,
     simulationState: kNullSimulationState,
     wormEatingDistance: "",
     wormEnergy: "",
@@ -200,7 +198,7 @@ class App extends React.Component<IAppProps, IAppState> {
     return (
       <div className="app">
         <PopulationsModelPanel hideModel={this.props.hideModel}
-                                year={this.state.year}
+                                simulationYear={simulationState.simulationYear}
                                 simulationStep={simulationStep}
                                 interactive={interactive}
                                 onSetInteractive={this.handleSetInteractive}/>
@@ -282,7 +280,7 @@ class App extends React.Component<IAppProps, IAppState> {
               </div>
             </div>
           </div>
-          <SimulationStatistics year={this.state.year} simulationState={simulationState}/>
+          <SimulationStatistics simulationState={simulationState}/>
         </div>
         <Attribution />
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,8 @@ class App extends React.Component<IAppProps, IAppState> {
       const yearRelativeStep = currentStats.simulationStep / (currentStats.simulationYear + 1);
       if (yearRelativeStep === currentStats.simulationYearLength - 1) {
         // TODO: this is where we can do more to "harvest" corn, store end-of-year stats, etc.
+        // Previously, end-of-year was handled as an environment rule, but this makes more sense since it
+        // should only execute once per step.
         endYear();
         // Ending year stops the simulation, and the result is still displayed. We ideally need another
         // step after this, to clear the sim (but not using the reset button), leaving just the eggs.

--- a/src/components/populations-model-panel.tsx
+++ b/src/components/populations-model-panel.tsx
@@ -8,7 +8,7 @@ const SEASONS = ["spring", "summer", "fall", "winter"];
 interface IProps {
   hideModel?: boolean;
   simulationYear: number;
-  simulationStep: number;
+  simulationStepInYear: number;
   interactive?: Interactive;
   onSetInteractive: (interactive: Interactive) => void;
 }
@@ -21,7 +21,7 @@ export default class PopulationsModelPanel extends React.Component<IProps, IStat
   };
 
   public render() {
-    const { simulationYear, simulationStep, interactive, onSetInteractive } = this.props,
+    const { simulationYear, simulationStepInYear, interactive, onSetInteractive } = this.props,
           populationsModel = !this.props.hideModel
                               ? <PopulationsModel
                                   interactive={interactive}
@@ -34,7 +34,7 @@ export default class PopulationsModelPanel extends React.Component<IProps, IStat
         {populationsModel}
         <TimelineView seasons={SEASONS} seasonLengths={seasonLengths}
                       simulationYear={simulationYear}
-                      simulationStep={simulationStep} />
+                      simulationStepInYear={simulationStepInYear} />
       </div>
     );
   }

--- a/src/components/populations-model-panel.tsx
+++ b/src/components/populations-model-panel.tsx
@@ -7,7 +7,7 @@ const SEASONS = ["spring", "summer", "fall", "winter"];
 
 interface IProps {
   hideModel?: boolean;
-  year: number;
+  simulationYear: number;
   simulationStep: number;
   interactive?: Interactive;
   onSetInteractive: (interactive: Interactive) => void;
@@ -21,7 +21,7 @@ export default class PopulationsModelPanel extends React.Component<IProps, IStat
   };
 
   public render() {
-    const { simulationStep, interactive, onSetInteractive } = this.props,
+    const { simulationYear, simulationStep, interactive, onSetInteractive } = this.props,
           populationsModel = !this.props.hideModel
                               ? <PopulationsModel
                                   interactive={interactive}
@@ -33,7 +33,8 @@ export default class PopulationsModelPanel extends React.Component<IProps, IStat
       <div className="populations-model-panel">
         {populationsModel}
         <TimelineView seasons={SEASONS} seasonLengths={seasonLengths}
-                      year={this.props.year} simulationStep={simulationStep} />
+                      simulationYear={simulationYear}
+                      simulationStep={simulationStep} />
       </div>
     );
   }

--- a/src/components/simulation-statistics.tsx
+++ b/src/components/simulation-statistics.tsx
@@ -3,7 +3,6 @@ import '../style/App.css';
 import { ISimulationState } from '../corn-model';
 
 interface IProps {
-  year: number;
   simulationState: ISimulationState;
 }
 

--- a/src/components/simulation-statistics.tsx
+++ b/src/components/simulation-statistics.tsx
@@ -18,6 +18,7 @@ interface IState {
   infectedCorn: number;
   harvestCorn: number;
   simulationDay: number;
+  simulationYear: number;
 }
 
 class SimulationStatistics extends React.Component<IProps, IState> {
@@ -32,15 +33,15 @@ class SimulationStatistics extends React.Component<IProps, IState> {
     totalWorm: 0,
     infectedCorn: 0,
     harvestCorn: 0,
-    simulationDay: 0
+    simulationDay: 0,
+    simulationYear: 0
   };
 
   static getDerivedStateFromProps(nextProps: IProps, prevState: IState) {
-    const { simulationStep, countCorn, countTrap, countWorm, infected } = nextProps.simulationState;
-    const actualDay = Math.trunc(simulationStep / 3);
+    const { simulationStep, simulationDay, simulationYear, countCorn, countTrap, countWorm, infected } = nextProps.simulationState;
 
     let nextState = { totalCorn: countCorn, totalTrap: countTrap, totalWorm: countWorm,
-                      infectedCorn: infected, simulationDay: actualDay };
+                      infectedCorn: infected, simulationDay, simulationYear};
     if (!simulationStep) {
       nextState = Object.assign(nextState, {
                                   initialCorn: countCorn, initialTrap: countTrap,
@@ -48,7 +49,7 @@ class SimulationStatistics extends React.Component<IProps, IState> {
                                 });
     }
     if ((prevState.dayFirstCornEaten == null) && (countCorn < prevState.initialCorn)) {
-      nextState = Object.assign(nextState, { dayFirstCornEaten: actualDay });
+      nextState = Object.assign(nextState, { dayFirstCornEaten: simulationDay });
     }
     return nextState;
   }
@@ -57,6 +58,7 @@ class SimulationStatistics extends React.Component<IProps, IState> {
     return (
       <div className="section stats">
         <h4>Statistics</h4>
+        <div><span>Year: </span><span>{this.state.simulationYear + 1}</span></div>
         <div><span>Day: </span><span>{this.state.simulationDay}</span></div>
         <div><span>Corn planted: </span><span>{this.state.initialCorn}</span></div>
         <div><span>Corn remaining: </span><span>{this.state.totalCorn}</span></div>

--- a/src/components/timeline-bar.tsx
+++ b/src/components/timeline-bar.tsx
@@ -5,7 +5,7 @@ import { sum } from 'lodash';
 interface IProps extends ISizeMeProps {
   seasons?: string[];
   seasonLengths?: number[];
-  simulationStep: number;
+  simulationStepInYear: number;
 }
 
 interface IState {}
@@ -20,7 +20,7 @@ class TimelineBar extends React.Component<IProps, IState> {
     const { size } = this.props,
           width = size && size.width || undefined,
           height = size && size.height || undefined,
-          { seasons, seasonLengths, simulationStep } = this.props,
+          { seasons, seasonLengths, simulationStepInYear } = this.props,
           yearLength = seasonLengths ? sum(seasonLengths) : 0,
           cumulativeLengths = seasonLengths && seasonLengths.map((length) => {
                                                 cumulativeLength += length;
@@ -41,7 +41,7 @@ class TimelineBar extends React.Component<IProps, IState> {
                                      </text>;
                             })
                           : 0,
-          xCurrent = (simulationStep  / yearLength) * (width || 0);
+          xCurrent = (simulationStepInYear  / yearLength) * (width || 0);
     return (
       <div className="timeline-bar">
         <svg width={width} height={height} >

--- a/src/components/timeline-view.tsx
+++ b/src/components/timeline-view.tsx
@@ -6,7 +6,7 @@ interface IProps extends ISizeMeProps {
   seasons?: string[];
   seasonLengths?: number[];
   simulationYear: number;
-  simulationStep: number;
+  simulationStepInYear: number;
 }
 
 interface IState {}
@@ -17,12 +17,14 @@ export default class TimelineView extends React.Component<IProps, IState> {
   };
 
   render() {
-    const { seasons, seasonLengths, simulationYear, simulationStep } = this.props,
+    const { seasons, seasonLengths, simulationYear, simulationStepInYear } = this.props,
           yearLabel = `Year ${simulationYear + 1}`;
     return (
       <div className="timeline-view">
         <span className='year-label'>{yearLabel}</span>
-        <TimelineBar seasons={seasons} seasonLengths={seasonLengths} simulationStep={simulationStep} />
+        <TimelineBar seasons={seasons}
+                    seasonLengths={seasonLengths}
+                    simulationStepInYear={simulationStepInYear} />
       </div>
     );
   }

--- a/src/components/timeline-view.tsx
+++ b/src/components/timeline-view.tsx
@@ -3,9 +3,9 @@ import TimelineBar from './timeline-bar';
 import '../style/timeline-view.css';
 
 interface IProps extends ISizeMeProps {
-  year: number;
   seasons?: string[];
   seasonLengths?: number[];
+  simulationYear: number;
   simulationStep: number;
 }
 
@@ -17,9 +17,8 @@ export default class TimelineView extends React.Component<IProps, IState> {
   };
 
   render() {
-    const { seasons, seasonLengths, simulationStep } = this.props,
-          year = this.props.year != null ? this.props.year + 1 : 1,
-          yearLabel = `Year ${year}`;
+    const { seasons, seasonLengths, simulationYear, simulationStep } = this.props,
+          yearLabel = `Year ${simulationYear + 1}`;
     return (
       <div className="timeline-view">
         <span className='year-label'>{yearLabel}</span>

--- a/src/corn-model.ts
+++ b/src/corn-model.ts
@@ -130,6 +130,8 @@ export function getCornStats(): ISimulationState {
     infected = 0;
   const simulationYear = Math.floor(env.date/simulationYearLengthInSteps);
   const simulationStep = env.date;
+  // currentYearStep is useful later on for agent rule tests - since those rules execute
+  // once per agent per step, this should improve performance.
   currentYearStep = env.date - (simulationYearLengthInSteps * simulationYear);
   const simulationDay = Math.round(currentYearStep / simulationStepToDayRatio);
 

--- a/src/corn-model.ts
+++ b/src/corn-model.ts
@@ -4,6 +4,13 @@ import { wormEgg } from './species/worm-egg';
 import { Agent, Environment, Rule, Interactive } from './populations';
 import { variedPlants } from './species/varied-plants';
 
+const simulationYearLengthInSteps: number = 600;
+const simulationStepToDayRatio: number = 3;
+let currentYearStep = 0;
+const eggHatchSeason = {
+  startStep: 50,
+  endStep: 60
+};
 const env = new Environment({
   columns:  45,
   rows:     45,
@@ -108,17 +115,24 @@ export interface ISimulationState {
   countTrap: number;
   countWorm: number;
   infected: number;
+  simulationDay: number;
   simulationStep: number;
+  simulationYear: number;
+  simulationYearLength: number;
 }
 export const kNullSimulationState =
-        { countCorn: 0, countTrap: 0, countWorm: 0, infected: 0, simulationStep: 0 };
+        { countCorn: 0, countTrap: 0, countWorm: 0, infected: 0, simulationDay: 0, simulationStep: 0, simulationYear: 0, simulationYearLength: simulationYearLengthInSteps };
 
 export function getCornStats(): ISimulationState {
   let countCorn = 0,
     countTrap = 0,
     countWorm = 0,
     infected = 0;
+  const simulationYear = Math.floor(env.date/simulationYearLengthInSteps);
   const simulationStep = env.date;
+  currentYearStep = env.date - (simulationYearLengthInSteps * simulationYear);
+  const simulationDay = Math.round(currentYearStep / simulationStepToDayRatio);
+
   env.agents.forEach((a) => {
     if (agentIsCorn(a)) {
       ++ countCorn;
@@ -133,7 +147,18 @@ export function getCornStats(): ISimulationState {
       ++countWorm;
     }
   });
-  return { countCorn, countTrap, countWorm, infected, simulationStep };
+  return { countCorn, countTrap, countWorm, infected, simulationDay, simulationStep, simulationYear, simulationYearLength: simulationYearLengthInSteps};
+}
+export function endYear() {
+  env.stop();
+  env.agents.forEach((a) => {
+    // we could store location of all eggs, remove everything, then re-create eggs, but it seems that just killing
+    // all the non-egg agents does the job just as well.
+    if (!agentIsEgg(a)) {
+      // kill off / remove all non-egg agents at end of year - this isn't visible until the simulation is restarted
+      a.die();
+    }
+  });
 }
 
 export interface IModelParams {
@@ -150,7 +175,8 @@ export function initCornModel(simulationElt: HTMLElement | null, params?: IModel
 
   env.addRule(new Rule({
     test(agent: Agent) {
-      return env.date > 50 && env.date < 60 && agentIsEgg(agent) && agent.get('hatched') === false;
+      // currentYearStep is updated once per step as part of the corn stats
+      return currentYearStep > eggHatchSeason.startStep && currentYearStep < eggHatchSeason.endStep && agentIsEgg(agent) && agent.get('hatched') === false;
     },
     action(agent: Agent) {
       agent.set('hatched', true);
@@ -168,20 +194,9 @@ export function initCornModel(simulationElt: HTMLElement | null, params?: IModel
     }
   }));
 
-  // limit growing season length - at the end of a year, the remaining corn is harvested
-  // NOTE: since rules are executed in the context of agents, this rule is not applied
-  // when there are no agents, and so the simulation runs forever. A simulation with
-  // no agents is unlikely to be useful, so it doesn't generally come up in practice,
-  // bit it can arise if all of the agents die, for instance.
-  env.addRule(new Rule({
-    test() {
-      return env.date >= 600;
-    },
-    action() {
-      env.stop();
-    }
-  }));
-
+  // NOTE: since rules are executed in the context of agents, if there are
+  // no agents, then no rules execute.
+  // Every rule test executes once per agent per step.
   env.addRule(new Rule({
     test(agent: Agent) {
       return agentIsWorm(agent) && getWormLifestage(agent) === wormLifestage.mature;

--- a/src/species/rootworm.ts
+++ b/src/species/rootworm.ts
@@ -111,7 +111,11 @@ class WormAnimal extends BasicAnimal {
     // Normally populations.js will smoothly grow the organism from invisible infant (0) to maturity (1), but
     // since worms hatch from eggs we need our worms to grow from small to mature
     const sizeScale = this.get('age') / maturity;
-    return Math.max(0.5, sizeScale);
+    if (sizeScale < 1) {
+      return Math.max(0.5, sizeScale);
+    } else {
+      return 1;
+    }
   }
 
   eat() {

--- a/src/species/rootworm.ts
+++ b/src/species/rootworm.ts
@@ -107,6 +107,13 @@ class WormAnimal extends BasicAnimal {
     }
   }
 
+  getSize() {
+    // Normally populations.js will smoothly grow the organism from invisible infant (0) to maturity (1), but
+    // since worms hatch from eggs we need our worms to grow from small to mature
+    const sizeScale = this.get('age') / maturity;
+    return Math.max(0.5, sizeScale);
+  }
+
   eat() {
     const nearest = this._nearestPrey();
     if (nearest) {
@@ -203,8 +210,7 @@ export const worm = new Species({
   speciesName: "Worm",
   agentClass: WormAnimal,
   defs: {
-    CHANCE_OF_MUTATION: 0,
-    MATURITY_AGE: maturity
+    CHANCE_OF_MUTATION: 0
   },
   traits: wormTraits,
   imageProperties:


### PR DESCRIPTION
This includes additional work for worm / egg lifecycle and for simulation year support.

At the end of the year, the simulation will stop, and the agents remaining will be killed - the removal of the dead agents isn't shown until the next year starts, so further work needs to be done here to perhaps advance the simulation by one day, thereby removing the dead agents, then leaving the simulation paused until the user can then add more corn and start the next year. The env.date will continue to increment.

No support in here yet for storing stats from previous years.