### PR TITLE
Stats table improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,16 +77,20 @@ class App extends React.Component<IAppProps, IAppState> {
     
     return (
       <div className="app">
-        <PopulationsModelPanel hideModel={this.props.hideModel}
-                                simulationYear={simulationState.simulationYear}
-                                simulationStepInYear={simulationStepInYear}
-                                interactive={interactive}
-                                onSetInteractive={this.handleSetInteractive}/>
-        <div className="ui">
-          <PlantingControls />
-          <WormTraitPanel />
-          <SimulationStatistics simulationState={simulationState} simulationHistory={this.simulationHistory}/>
+        <div className="simulation-and-control-panels">
+          <div className="simulation-column">
+            <PopulationsModelPanel hideModel={this.props.hideModel}
+                                    simulationYear={simulationState.simulationYear}
+                                    simulationStepInYear={simulationStepInYear}
+                                    interactive={interactive}
+                                    onSetInteractive={this.handleSetInteractive}/>
+          </div>
+          <div className="controls-column">
+            <PlantingControls />
+            <WormTraitPanel />
+          </div>
         </div>
+        <SimulationStatistics simulationState={simulationState} simulationHistory={this.simulationHistory}/>
         <Attribution />
       </div>
     );

--- a/src/components/simulation-statistics.tsx
+++ b/src/components/simulation-statistics.tsx
@@ -66,7 +66,7 @@ class SimulationStatistics extends React.Component<IProps, IState> {
     for (let year = 0; year <= this.state.simulationYear; ++year) {
       yearCells.push(
         <th className="column-header" scope="col" key={year + 1}>
-          Yr {year + 1}
+          {year + 1}
         </th>
       );
     }
@@ -98,11 +98,13 @@ class SimulationStatistics extends React.Component<IProps, IState> {
 
   public render() {
     return (
-      <div className="section stats">
-        <h4>Statistics</h4>
-        <table className="simulation-stats">
+      <div className="simulation-stats">
+        <table className="stats-table">
           <tbody>
-            <tr className="column-header-row"><td/>{this.renderYearHeaders()}</tr>
+            <tr className="column-header-row">
+              <th>Year</th>
+              {this.renderYearHeaders()}
+            </tr>
             {this.renderInitialDataRow("Corn planted",
                                       state => state.initial.countCorn,
                                       this.state.initialCorn)}

--- a/src/style/App.css
+++ b/src/style/App.css
@@ -1,16 +1,27 @@
 .app {
   display: flex;
+  flex-direction: column;
 }
 
-.ui {
+.simulation-and-control-panels {
+  display: flex;
+  flex-direction: row;
+}
+
+.controls-column {
   font-size: 0.8em;
   max-width: 400px;
   margin-top: 10px;
   margin-left: 20px;
 }
 
-.ui .section{
+.controls-column .section {
   border: 1px solid silver;
   padding: 10px;
   margin-bottom: 10px;
+}
+
+.simulation-stats {
+  margin-left: 10px;
+  margin-top: 16px;
 }

--- a/src/style/simulation-statistics.css
+++ b/src/style/simulation-statistics.css
@@ -1,11 +1,19 @@
+.simulation-stats {
+  font-size: 0.8em;
+}
+
 .simulation-stats .column-header {
   padding-left: 6px;
+  background-color: lightgray;
+  text-align: center;
 }
 
 .simulation-stats .row-header {
   text-align: left;
+  background-color: lightgray;
 }
 
 .simulation-stats .data-row td {
+  min-width: 30px;
   text-align: right;
 }


### PR DESCRIPTION
- move table below simulation so it has more room to grow
- format row and column headers
- CC attribution logo goes behind table (or other UI elements) if they overlap