### PR TITLE
Support multiple trait panels including new crop trait configuration panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "lodash": "^4.17.10",
+    "query-string": "^6.1.0",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-scripts-ts": "2.15.1",
@@ -25,6 +26,7 @@
     "@types/jquery": "^3.3.1",
     "@types/lodash": "^4.14.108",
     "@types/node": "^10.0.3",
+    "@types/query-string": "^5.1.0",
     "@types/react": "^16.3.13",
     "@types/react-dom": "^16.0.5",
     "jquery": "^3.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import PlantingControls from './components/planting-controls';
 import PopulationsModelPanel from './components/populations-model-panel';
 import SimulationStatistics, { ISimulationYearState } from './components/simulation-statistics';
 import MultiTraitPanel from './components/multi-trait-panel';
+import { urlParams } from './utilities/url-params';
+const isInConfigurationMode = urlParams.config !== undefined;
 
 interface IAppProps {
   hideModel?: boolean;
@@ -87,7 +89,7 @@ class App extends React.Component<IAppProps, IAppState> {
           </div>
           <div className="controls-column">
             <PlantingControls />
-            <MultiTraitPanel />
+            {isInConfigurationMode ? <MultiTraitPanel /> : null}
           </div>
         </div>
         <SimulationStatistics simulationState={simulationState} simulationHistory={this.simulationHistory}/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import Attribution from './components/attribution';
 import PlantingControls from './components/planting-controls';
 import PopulationsModelPanel from './components/populations-model-panel';
 import SimulationStatistics, { ISimulationYearState } from './components/simulation-statistics';
-import WormTraitPanel from './components/worm-trait-panel';
+import MultiTraitPanel from './components/multi-trait-panel';
 
 interface IAppProps {
   hideModel?: boolean;
@@ -87,7 +87,7 @@ class App extends React.Component<IAppProps, IAppState> {
           </div>
           <div className="controls-column">
             <PlantingControls />
-            <WormTraitPanel />
+            <MultiTraitPanel />
           </div>
         </div>
         <SimulationStatistics simulationState={simulationState} simulationHistory={this.simulationHistory}/>

--- a/src/components/crop-trait-panel.tsx
+++ b/src/components/crop-trait-panel.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import ConfigurableTrait from './configurable-trait';
+import { Species } from '../populations';
+import { corn } from '../species/corn';
+import { variedPlants } from '../species/varied-plants';
+
+interface ITraitSpec {
+  species: Species;
+  traitName: string;
+}
+const traitMap: { [key: string]: ITraitSpec } = {
+  'trait-corn-health': {
+    species: corn,
+    traitName: 'health',
+  },
+  'trait-corn-worm-preference': {
+    species: corn,
+    traitName: 'worm preference',
+  },
+  'trait-corn-worm-nutrition': {
+    species: corn,
+    traitName: 'worm nutrition',
+  },
+  'trait-trap-health': {
+    species: variedPlants,
+    traitName: 'health',
+  },
+  'trait-trap-worm-preference': {
+    species: variedPlants,
+    traitName: 'worm preference',
+  },
+  'trait-trap-worm-nutrition': {
+    species: variedPlants,
+    traitName: 'worm nutrition',
+  }
+};
+
+interface IProps {
+}
+
+interface IState {}
+
+export default class CropTraitPanel extends React.Component<IProps, IState> {
+
+  state: IState = {
+  };
+
+  getDefaultTraitValue = (id: string) => {
+    const spec = traitMap[id],
+          trait = spec && spec.species.getTrait(spec.traitName),
+          defaultValue = trait && trait.getDefaultValue();
+    return defaultValue != null ? String(defaultValue) : "";
+  }
+
+  setDefaultTraitValue = (id: string, value: number) => {
+    const traitSpec = traitMap[id],
+          traitSpecies = traitSpec && traitSpec.species,
+          traitName = traitSpec && traitSpec.traitName,
+          trait = traitSpecies && traitSpecies.getTrait(traitName);
+    if (trait) {
+      trait.default = value;
+    }
+  }
+
+  render() {
+
+    const renderConfigTrait = (label: string, helpText: string, inputID: string) => {
+      // inputID should correspond to entry in trait map
+      if (!traitMap[inputID]) {
+        console.error(`Invalid trait ID: '${inputID}'`);
+      }
+      return (
+        <ConfigurableTrait
+          label={label}
+          helpText={helpText}
+          inputID={inputID}
+          initialValue={this.getDefaultTraitValue(inputID)}
+          onBlur={this.setDefaultTraitValue}
+        />
+      );
+    };
+
+    return (
+      <div className="crop-trait-panel">
+        {renderConfigTrait(
+          "Corn health:",
+          "Health is reduced when the plant is eaten. If reduced to 0 the plant dies.",
+          "trait-corn-health")}
+        {renderConfigTrait(
+          "Rootworm corn preference:",
+          "Attractiveness of corn to rootworms",
+          "trait-corn-worm-preference")}
+        {renderConfigTrait(
+          "Rootworm corn nutrition:",
+          "Nutritional value of corn to rootworms (1 = 100%)",
+          "trait-corn-worm-nutrition")}
+        <br/>
+        {renderConfigTrait(
+          "Alfalfa health:",
+          "Health is reduced when the plant is eaten. If reduced to 0 the plant dies.",
+          "trait-trap-health")}
+        {renderConfigTrait(
+          "Rootworm alfalfa preference:",
+          "Attractiveness of alfalfa to rootworms",
+          "trait-trap-worm-preference")}
+        {renderConfigTrait(
+          "Rootworm alfalfa nutrition:",
+          "Nutritional value of alfalfa to rootworms (1 = 100%)",
+          "trait-trap-worm-nutrition")}
+      </div>
+    );
+  }
+}

--- a/src/components/multi-trait-panel.tsx
+++ b/src/components/multi-trait-panel.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import CropTraitPanel from './crop-trait-panel';
+import WormTraitPanel from './worm-trait-panel';
+import '../style/multi-trait-panel.css';
+
+interface IProps {
+}
+
+interface IState {
+  panel: string;
+}
+
+export default class MultiTraitPanel extends React.Component<IProps, IState> {
+
+  state: IState = {
+    panel: 'crop'
+  };
+
+  handleChange = (evt: React.FormEvent<HTMLSelectElement>) => {
+    this.setState({ panel: evt.currentTarget.value });
+  }
+
+  render() {
+    const { panel } = this.state,
+          cropTraitPanel = panel === 'crop' ? <CropTraitPanel /> : null,
+          wormTraitPanel = panel === 'worm' ? <WormTraitPanel /> : null;
+
+    return (
+      <div className="section sim-adjustment">
+        <label className="configure-panel-label">
+          Configure:&nbsp;&nbsp;
+          <select className="configure-panel-select"
+                  value={this.state.panel}
+                  onChange={this.handleChange}>
+            <option value="crop">Crops</option>
+            <option value="worm">Rootworms</option>
+          </select>
+        </label>
+        <br/>
+        <br/>
+        {cropTraitPanel}
+        {wormTraitPanel}
+      </div>
+    );
+  }
+}

--- a/src/components/worm-trait-panel.tsx
+++ b/src/components/worm-trait-panel.tsx
@@ -97,8 +97,7 @@ export default class WormTraitPanel extends React.Component<IProps, IState> {
     };
 
     return (
-      <div className="section sim-adjustment">
-        <h4>Worms</h4>
+      <div className="worm-trait-panel">
         {renderConfigTrait(
           "Sensing Distance (larva):",
           "Controls the distance that the larval form of the worm can sense nearby food (crops)",

--- a/src/species/corn.ts
+++ b/src/species/corn.ts
@@ -54,15 +54,7 @@ const getLifestage = (agent: Agent): number => {
   return stage;
 };
 
-const cornInfectedTrait = new Trait({
-  name: 'infected',
-  possibleValues: [ true, false ],
-  default: false,
-  float: false,
-  mutatable: false
-});
-
-const cornHealthTrait = new Trait({
+const healthTrait = new Trait({
   name: 'health',
   min: 0,
   max: 100,
@@ -71,6 +63,27 @@ const cornHealthTrait = new Trait({
   mutatable: false
 });
 
+// degree to which rootworm prefers corn relative to
+// other prey items (e.g. trap crop)
+const wormPreference = new Trait({
+  name: 'worm preference',
+  min: 0,
+  max: 100,
+  default: 1,
+  float: true,
+  mutatable: false
+});
+
+// nutritional value of the corn to rootworm; multiplied by
+// rootworm's consumption rate to determine energy gained
+const wormNutrition = new Trait({
+  name: 'worm nutrition',
+  min: 0,
+  max: 1,
+  default: 1,
+  float: true,
+  mutatable: false
+});
 
 const healthyTolerance = 90;
 
@@ -86,7 +99,7 @@ export const corn = new Species({
     SPROUT_AGE: 10,
     MATURITY_AGE: maturity
   },
-  traits: [cornInfectedTrait, cornHealthTrait],
+  traits: [healthTrait, wormPreference, wormNutrition],
   imageRules: [
     {
       name: 'corn',

--- a/src/species/rootworm.ts
+++ b/src/species/rootworm.ts
@@ -151,10 +151,10 @@ class WormAnimal extends BasicAnimal {
   }
 
   _eatPrey(prey: Agent) {
-    const preyIsTrap = prey.species.speciesName === "Trap";
     const consumptionRate = this.get('resource consumption rate');
+    const nutritionFactor = prey.get('worm nutrition') || 1;
     const currEnergy = this.get('energy');
-    const deltaEnergy = preyIsTrap ? consumptionRate / 5 : consumptionRate;
+    const deltaEnergy = nutritionFactor * consumptionRate;
 
     this.set('energy', currEnergy + deltaEnergy);
 
@@ -201,25 +201,15 @@ class WormAnimal extends BasicAnimal {
     const prey: IPrey[] = this.get('prey');
     if (prey && prey.length) {
       const nearest = this._nearestAgentsMatching({ types: prey, quantity: 100 });
-      const target = nearest[0],
-            targetWasCorn = target && target.agent.species.speciesName === 'Corn';
       nearest.forEach((a) => {
-        const preyName = a.agent.species.speciesName,
-              // determine preference for this prey
-              preyPreference = prey.reduce((prev: number, curr: IPrey) =>
-                ((curr.name === preyName) && (curr.preference != null))
-                  ? prev * curr.preference : prev, 1);
+        // determine preference for this prey
+        const preyPreference = a.agent.get('worm preference') || 1;
         // adjust distance based on preference
         a.distanceSq /= preyPreference;
       });
       // sort by preference-adjusted distance
       nearest.sort((a, b) => a.distanceSq - b.distanceSq);
       // for now, return the most-preferred prey
-      const newTarget = nearest[0],
-            targetIsTrap = newTarget && newTarget.agent.species.speciesName === 'Trap';
-      if (targetWasCorn && targetIsTrap) {
-        // console.log(`Worm targeting more distant trap plant!`);
-      }
       return nearest[0] || null;
     }
     return null;

--- a/src/species/varied-plants.ts
+++ b/src/species/varied-plants.ts
@@ -4,7 +4,7 @@ const kPlantScale = 0.1;
 const kFlowerAnchorX = 0;
 const kFlowerAnchorY = -30;
 
-const trapHealthTrait = new Trait({
+const healthTrait = new Trait({
   name: 'health',
   min: 0,
   max: 100,
@@ -13,7 +13,30 @@ const trapHealthTrait = new Trait({
   mutatable: false
 });
 
-export const variedPlants: Species = new Species({
+// degree to which rootworm prefers this relative to other prey items (e.g. corn)
+// squared distance is divided by this when determining preference, so a value
+// of four makes it equal in preference to prey with a value of 1 at half the distance.
+const wormPreference = new Trait({
+  name: 'worm preference',
+  min: 0,
+  max: 100,
+  default: 20,  // substantially preferred
+  float: true,
+  mutatable: false
+});
+
+// nutritional value of the corn to rootworm; multiplied by
+// rootworm's consumption rate to determine energy gained
+const wormNutrition = new Trait({
+  name: 'worm nutrition',
+  min: 0,
+  max: 1,
+  default: 0.2, // substantially less nutritional value
+  float: true,
+  mutatable: false
+});
+
+export const variedPlants = new Species({
   speciesName: "Trap",
   agentClass: BasicPlant,
   defs: {
@@ -31,7 +54,7 @@ export const variedPlants: Species = new Species({
     }
   },
   traits: [
-    trapHealthTrait,
+    healthTrait, wormPreference, wormNutrition,
     new Trait({ name: "size", min: 1, max: 10, mutatable: true }),
     new Trait({ name: "root size", min: 1, max: 10, mutatable: true })
   ],

--- a/src/style/App.css
+++ b/src/style/App.css
@@ -10,6 +10,7 @@
 
 .controls-column {
   font-size: 0.8em;
+  min-width: 280px;
   max-width: 400px;
   margin-top: 10px;
   margin-left: 20px;

--- a/src/style/configurable-trait.css
+++ b/src/style/configurable-trait.css
@@ -1,6 +1,6 @@
 .config-trait-label {
   display: inline-block;
-  width: 180px;
+  width: 190px;
 }
 
 .config-trait-input {

--- a/src/style/multi-trait-panel.css
+++ b/src/style/multi-trait-panel.css
@@ -1,0 +1,3 @@
+.configure-panel-label {
+  font-weight: bold;
+}

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -1,0 +1,3 @@
+import { parse } from 'query-string';
+
+export const urlParams = parse(location.search);

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,10 @@
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.3.tgz#1f89840c7aac2406cc43a2ecad98fc02a8e130e4"
 
+"@types/query-string@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-5.1.0.tgz#7f40cdea49ddafa0ea4f3db35fb6c24d3bfd4dcc"
+
 "@types/react-dom@^16.0.5":
   version "16.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.5.tgz#a757457662e3819409229e8f86795ff37b371f96"
@@ -5552,6 +5556,13 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6484,6 +6495,10 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Add Crops trait configuration panel
- move prey preference constants into traits
- move prey nutrition constants into traits
- add CropTraitPanel
- add MultiTraitPanel which allows user to select CropTraitPanel or WormTraitPanel

Support `config` URL parameter
- multi-trait configuration panel only shows when `config` is present

@dstrawberrygirl Note that this is dependent on the prior PR. For review purposes, it may be easier to review the other PR first and then I can rebase this one on top of the other to simplify the review.