### PR TITLE
Fix Firefox layout bug

### DIFF
--- a/src/components/attribution.tsx
+++ b/src/components/attribution.tsx
@@ -25,7 +25,7 @@ class Attribution extends React.Component<{}, IAttributionState> {
       <div className="attribution-text">
         <div className="small-logo" onClick={this.toggleAttribution} />
         <div>This interactive was created by the Concord Consortium using our Populations library.</div>
-        <div>Copyright © 2018 The Concord Consortium. All rights reserved. The software is licensed under the MIT license. Please see <a href="https://github.com/concord-consortium/dat-cross-farm/blob/master/LICENSE" target="_blank">license</a> for other software and associated licensing included in this product. Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" target="_blank">https://concord.org</a>.</div>
+        <div>Copyright © 2018 The Concord Consortium. All rights reserved. The software is licensed under the MIT license. Please see <a href="https://github.com/concord-consortium/dat-cross-farm/blob/master/LICENSE" target="_blank" rel="noopener">license</a> for other software and associated licensing included in this product. Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" target="_blank" rel="noopener">https://concord.org</a>.</div>
       </div>
     </div>
     </div>

--- a/src/style/App.css
+++ b/src/style/App.css
@@ -8,6 +8,10 @@
   flex-direction: row;
 }
 
+.populations-model-panel {
+  max-width: 538px; /* hard-coded for now to fix Firefox layout issue */
+}
+
 .controls-column {
   font-size: 0.8em;
   min-width: 280px;


### PR DESCRIPTION
[#157675435] Fix Firefox layout bug

Add `rel="noopener'` to about box links for security reasons
cf. http://mathiasbynens.github.io/rel-noopener/
