### PR TITLE
Eliminate Plant Corn/Alfalfa and Add Worms buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import './style/App.css';
 import {
-  getCornStats, ISimulationState, kNullSimulationState,
-  simulationStepsPerYear, prepareToEndYear, endYear
+  getCornStats, ISimulationState, kNullSimulationState, simulationStepsPerYear,
+  addWormsSparse, plantMixedCrop, prepareToEndYear, endYear
 } from './corn-model';
 import { Events, Environment, Interactive } from './populations';
 import Attribution from './components/attribution';
@@ -20,6 +20,7 @@ interface IAppProps {
 interface IAppState {
   interactive?: Interactive;
   simulationState: ISimulationState;
+  cornPct: number;
 }
 
 class App extends React.Component<IAppProps, IAppState> {
@@ -27,7 +28,8 @@ class App extends React.Component<IAppProps, IAppState> {
   simulationHistory: ISimulationYearState[];
 
   public state: IAppState = {
-    simulationState: kNullSimulationState
+    simulationState: kNullSimulationState,
+    cornPct: 100
   };
 
   constructor(props: IAppProps) {
@@ -36,41 +38,73 @@ class App extends React.Component<IAppProps, IAppState> {
   }
 
   public componentDidMount() {
+
     Events.addEventListener(Environment.EVENTS.START, (evt: any) => {
-      const simulationState = getCornStats(),
-            { simulationStepInYear } = simulationState;
-      if (simulationStepInYear === 0) {
-        this.simulationHistory.push({ initial: simulationState });
-        this.setState({ simulationState });
-      }
+      this.handleSimulationStart();
     });
 
     Events.addEventListener(Environment.EVENTS.STEP, (evt: any) => {
-      const simulationState = getCornStats(),
-            { simulationStepInYear, simulationYear } = simulationState;
-      this.setState({ simulationState });
-      // last step of the year
-      if (simulationStepInYear === simulationStepsPerYear - 1) {
-        // TODO: this is where we can do more to "harvest" corn, store end-of-year stats, etc.
-        // Previously, end-of-year was handled as an environment rule, but this makes more sense since it
-        // should only execute once per step.
-        this.simulationHistory[simulationYear].final = simulationState;
-        prepareToEndYear();
-      }
-      // stop at the end of the year before starting the new year
-      else if (simulationStepInYear === 0) {
-        endYear();
-      }
+      this.handleSimulationStep();
     });
 
     Events.addEventListener(Environment.EVENTS.RESET, (evt: any) => {
-      this.simulationHistory = [];
-      this.setState({ simulationState: kNullSimulationState });
+      this.handleSimulationReset();
     });
   }
 
   handleSetInteractive = (interactive: Interactive) => {
     this.setState({ interactive });
+  }
+
+  handleSimulationStart() {
+    const { simulationStepInYear } = getCornStats();
+    if (simulationStepInYear === 0) {
+      // plant the crop before proceeding
+      plantMixedCrop(this.state.cornPct);
+      // retrieve post-planting stats
+      const simulationState = getCornStats();
+      this.simulationHistory.push({ initial: simulationState });
+      this.setState({ simulationState });
+      // if this is the infestation year, then add rootworms
+      if (simulationState.simulationYear > 0) {
+        const prevYear = this.simulationHistory.length - 2,
+              prevYearStats = this.simulationHistory[prevYear];
+        // worms infest after a full year without worms, which is
+        // generally year 2 and any subsequent year after worms
+        // have been eradicated for an entire year.
+        if (!prevYearStats.initial.countWorm &&
+            prevYearStats.final && !prevYearStats.final.countWorm) {
+          addWormsSparse();
+        }
+      }
+    }
+  }
+
+  handleSimulationStep() {
+    const simulationState = getCornStats(),
+          { simulationStepInYear, simulationYear } = simulationState;
+    this.setState({ simulationState });
+    // last step of the year
+    if (simulationStepInYear === simulationStepsPerYear - 1) {
+      // TODO: this is where we can do more to "harvest" corn, store end-of-year stats, etc.
+      // Previously, end-of-year was handled as an environment rule, but this makes more sense since it
+      // should only execute once per step.
+      this.simulationHistory[simulationYear].final = simulationState;
+      prepareToEndYear();
+    }
+    // stop at the end of the year before starting the new year
+    else if (simulationStepInYear === 0) {
+      endYear();
+    }
+  }
+
+  handleSimulationReset() {
+    this.simulationHistory = [];
+    this.setState({ simulationState: kNullSimulationState });
+  }
+
+  onSetCornPct = (cornPct: number) => {
+    this.setState({ cornPct });
   }
 
   public render() {
@@ -88,7 +122,7 @@ class App extends React.Component<IAppProps, IAppState> {
                                     onSetInteractive={this.handleSetInteractive}/>
           </div>
           <div className="controls-column">
-            <PlantingControls />
+            <PlantingControls cornPct={this.state.cornPct} onSetCornPct={this.onSetCornPct}/>
             {isInConfigurationMode ? <MultiTraitPanel /> : null}
           </div>
         </div>

--- a/src/components/planting-controls.tsx
+++ b/src/components/planting-controls.tsx
@@ -1,59 +1,31 @@
 import * as React from 'react';
-import { addCornDense, addCornSparse, addTrapCropDense, addTrapCropSparse, plantMixedCrop, addWormsSparse }
-  from '../corn-model';
 
 interface IProps {
+  cornPct: number;
+  onSetCornPct: (cornPct: number) => void;
 }
 interface IState {
-  cornPct: number;
 }
 
 export default class PlantingControls extends React.Component<IProps, IState> {
 
   state: IState = {
-    cornPct: 100
   };
 
-  plantCornDensely = () => {
-    addCornDense();
-  }
-
-  plantCornSparsely = () => {
-    addCornSparse();
-  }
-
-  plantTrapCropDensely = () => {
-    addTrapCropDense();
-  }
-
-  plantTrapCropSparsely = () => {
-    addTrapCropSparse();
-  }
-
-  addWorms = () => {
-    addWormsSparse();
-  }
-
   handleCornPctChange = (evt: React.FormEvent<HTMLSelectElement>) => {
-    this.setState({ cornPct: Number(evt.currentTarget.value) });
-  }
-
-  plantCrop = () => {
-    plantMixedCrop(this.state.cornPct);
+    this.props.onSetCornPct(Number(evt.currentTarget.value));
   }
 
   render() {
-    const trapPct = 100 - this.state.cornPct,
-          plantButtonLabel = trapPct === 0
-                              ? "Plant Corn"
-                              : (trapPct === 100 ? "Plant Alfalfa" : "Plant Corn & Alfalfa");
+    const { cornPct } =  this.props,
+          trapPct = 100 - cornPct;
     return (
       <div className="section planting-controls">
         <h4>Planting Controls</h4>
         <label>
-          Corn:&nbsp;
+          Corn:&nbsp;&nbsp;
           <select className="corn-percent-select"
-                  value={this.state.cornPct}
+                  value={cornPct}
                   onChange={this.handleCornPctChange}>
             <option value="0">0%</option>
             <option value="25">25%</option>
@@ -64,17 +36,7 @@ export default class PlantingControls extends React.Component<IProps, IState> {
         </label>
         <br/>
         <br/>
-        <div>Alfalfa: {trapPct}%</div>
-        <br/>
-        <div>
-          <button id="plant-crop" onClick={this.plantCrop}>
-            {plantButtonLabel}
-          </button>
-        </div>
-        <br/>
-        <div><button id="add-worms-sparse" onClick={this.addWorms}>
-          Add Worms
-        </button></div>
+        <div>Alfalfa:&nbsp;&nbsp;{trapPct}%</div>
       </div>
     );
   }


### PR DESCRIPTION
Eliminate `Add Worms` button

Corn is planted when user clicks start simulation buttons
Rootworms are automatically added after a full year without worms, i.e. year 2 and a year after they've been eradicated in any subsequent year.