### PR TITLE
Add bar charts for corn and rootworm egg stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-scripts-ts": "2.15.1",
-    "react-sizeme": "2.4.1"
+    "react-sizeme": "2.4.1",
+    "recharts": "^1.0.0-beta.10"
   },
   "scripts": {
     "lint": "tslint --project .",
@@ -29,6 +30,7 @@
     "@types/query-string": "^5.1.0",
     "@types/react": "^16.3.13",
     "@types/react-dom": "^16.0.5",
+    "@types/recharts": "^1.0.20",
     "jquery": "^3.3.1",
     "typescript": "^2.8.3"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import PopulationsModelPanel from './components/populations-model-panel';
 import SimulationStatistics from './components/simulation-statistics';
 import { SimulationHistory } from './models/simulation-history';
 import MultiTraitPanel from './components/multi-trait-panel';
+import CornChart from './components/corn-chart';
+import WormChart from './components/worm-chart';
 import { urlParams } from './utilities/url-params';
 const isInConfigurationMode = urlParams.config !== undefined;
 const isInQuietMode = urlParams.quiet !== undefined;
@@ -136,6 +138,12 @@ class App extends React.Component<IAppProps, IAppState> {
                                 onToggleVisibility={this.handleToggleInitialDialogVisibility} />
                             : null,
           historyLength = this.simulationHistory.length,
+          cornChart = historyLength >= 1 && this.simulationHistory[0].final
+                        ? <CornChart simulationHistory={this.simulationHistory} />
+                        : null,
+          wormChart = historyLength >= 1 && this.simulationHistory[0].final
+                        ? <WormChart simulationHistory={this.simulationHistory} />
+                        : null,
           prevYear = historyLength >= 1 ? historyLength - 1 : 0,
           prevYearStats = this.simulationHistory[prevYear],
           endSeasonDialog = showEndSeasonDialog
@@ -159,6 +167,8 @@ class App extends React.Component<IAppProps, IAppState> {
             <PlantingControls year={simulationYear + 1} cornPct={cornPct}
                               onSetCornPct={this.onSetCornPct}/>
             {isInConfigurationMode ? <MultiTraitPanel /> : null}
+            {!isInConfigurationMode ? cornChart : null}
+            {!isInConfigurationMode ? wormChart : null}
           </div>
         </div>
         <SimulationStatistics simulationState={simulationState} simulationHistory={this.simulationHistory}/>

--- a/src/components/corn-chart.tsx
+++ b/src/components/corn-chart.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+// import * as sizeMe from 'react-sizeme';
+import { SimulationHistory } from '../models/simulation-history';
+import {BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend} from 'recharts';
+
+interface IProps extends ISizeMeProps {
+  simulationHistory: SimulationHistory;
+}
+
+interface IState {}
+
+export default class CornChart extends React.Component<IProps, IState> {
+
+  state: IState = {
+  };
+
+  render() {
+    const { simulationHistory } = this.props,
+          // width = size && size.width || 0,
+          // height = size && size.height || 0,
+          filtered = simulationHistory.filter((x) => x.initial && x.final),
+          // show last five years
+          cropped = filtered.filter((x, i) => i >= filtered.length - 5),
+          cornData = cropped.map((x) => ({
+                      year: `Year ${x.initial.simulationYear + 1}`,
+                      planted: x.initial.countCorn,
+                      harvested: x.final && x.final.countCorn
+                    }));
+    return (
+    	<BarChart width={300} height={180} data={cornData} barGap={0}
+            margin={{top: 5, right: 30, left: 20, bottom: 5}}>
+       <CartesianGrid strokeDasharray="3 3"/>
+       <XAxis dataKey="year"/>
+       <YAxis label={{ value: 'Corn', angle: -90, position: 'insideLeft' } as any}/>
+       <Tooltip/>
+       <Legend />
+       <Bar dataKey="planted" fill="#8884d8" />
+       <Bar dataKey="harvested" fill="#82ca9d" />
+      </BarChart>
+    );
+  }
+}
+
+// const sizeMeConfig = { monitorWidth: true, monitorHeight: true, noPlaceholder: true };
+// export default sizeMe(sizeMeConfig)(CornChart as any);

--- a/src/components/worm-chart.tsx
+++ b/src/components/worm-chart.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+// import * as sizeMe from 'react-sizeme';
+import { SimulationHistory } from '../models/simulation-history';
+import {BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend} from 'recharts';
+
+interface IProps extends ISizeMeProps {
+  simulationHistory: SimulationHistory;
+}
+
+interface IState {}
+
+export default class WormChart extends React.Component<IProps, IState> {
+
+  state: IState = {
+  };
+
+  render() {
+    const { simulationHistory } = this.props,
+          // width = size && size.width || 0,
+          // height = size && size.height || 0,
+          filtered = simulationHistory.filter((x) => x.initial && x.final),
+          // show last five years
+          cropped = filtered.filter((x, i) => i >= filtered.length - 5),
+          wormData = cropped.map((x) => ({
+                      year: `Year ${x.initial.simulationYear + 1}`,
+                      initial: x.initial.countEggs,
+                      final: x.final && x.final.countEggs
+                    }));
+    return (
+    	<BarChart width={300} height={180} data={wormData} barGap={0}
+            margin={{top: 5, right: 30, left: 20, bottom: 5}}>
+       <CartesianGrid strokeDasharray="3 3"/>
+       <XAxis dataKey="year"/>
+       <YAxis label={{ value: 'Rootworm Eggs', angle: -90, position: 'insideBottomLeft' } as any}/>
+       <Tooltip/>
+       <Legend />
+       <Bar dataKey="initial" fill="#8884d8" />
+       <Bar dataKey="final" fill="#82ca9d" />
+      </BarChart>
+    );
+  }
+}
+
+// const sizeMeConfig = { monitorWidth: true, monitorHeight: true, noPlaceholder: true };
+// export default sizeMe(sizeMeConfig)(CornChart as any);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,16 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/d3-path@*":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.6.tgz#c1a7d2dc07b295fdd1c84dabe4404df991b48693"
+
+"@types/d3-shape@*":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.2.2.tgz#f8dcdff7772a7ae37858bf04abd43848a78e590e"
+  dependencies:
+    "@types/d3-path" "*"
+
 "@types/jest@^22.2.3":
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
@@ -48,6 +58,13 @@
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.13.tgz#47d466462b774556c1174ea0eda22c0578643362"
   dependencies:
     csstype "^2.2.0"
+
+"@types/recharts@^1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@types/recharts/-/recharts-1.0.20.tgz#3f31d456611002a4ed861d9ff97c162579b4c031"
+  dependencies:
+    "@types/d3-shape" "*"
+    "@types/react" "*"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -1434,6 +1451,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
@@ -1660,6 +1681,10 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-js@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -1884,6 +1909,60 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+d3-array@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
+
+d3-collection@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
+
+d3-color@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.0.tgz#d1ea19db5859c86854586276ec892cf93148459a"
+
+d3-format@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.0.tgz#a3ac44269a2011cdb87c7b5693040c18cddfff11"
+
+d3-interpolate@1, d3-interpolate@^1.1.5:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.2.0.tgz#40d81bd8e959ff021c5ea7545bc79b8d22331c41"
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
+
+d3-scale@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.1.tgz#85b7cdfbc9ffca187f14d3c456ffda268081bb31"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -2089,6 +2168,10 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+dom-helpers@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0:
   version "0.1.0"
@@ -4298,7 +4381,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5481,7 +5564,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -5579,7 +5662,7 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
-raf@3.4.0:
+raf@3.4.0, raf@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -5663,6 +5746,12 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-resize-detector@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-1.1.0.tgz#4a9831fa3caad32230478dd0185cbd2aa91a5ebf"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-scripts-ts@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/react-scripts-ts/-/react-scripts-ts-2.15.1.tgz#98032840e61faff65e59047036a7fa236568d503"
@@ -5715,6 +5804,23 @@ react-sizeme@2.4.1:
     invariant "^2.2.2"
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
+
+react-smooth@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.0.tgz#b29dbebddddb06d21b5b08962167fb9eac1897d8"
+  dependencies:
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    raf "^3.2.0"
+    react-transition-group "^2.2.1"
+
+react-transition-group@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.1"
 
 react@^16.3.2:
   version "16.3.2"
@@ -5791,6 +5897,26 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+recharts-scale@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.3.2.tgz#dac7621714a4765d152cb2adbc30c73b831208c9"
+
+recharts@^1.0.0-beta.10:
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.0.0-beta.10.tgz#d3cd15df6b7879d5968da3c942b5fcdaf2504fe1"
+  dependencies:
+    classnames "2.2.5"
+    core-js "2.5.1"
+    d3-interpolate "^1.1.5"
+    d3-scale "1.0.6"
+    d3-shape "1.2.0"
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    react-resize-detector "1.1.0"
+    react-smooth "1.0.0"
+    recharts-scale "0.3.2"
+    reduce-css-calc "1.3.0"
+
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -5804,7 +5930,7 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-reduce-css-calc@^1.2.6:
+reduce-css-calc@1.3.0, reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
   dependencies:


### PR DESCRIPTION
Add bar charts for corn and rootworm egg stats [#157757130]

Note: the story asks for adult and egg numbers for rootworm stats, but since our results are for the end of the season, there are never any adult rootworms. Therefore, I'm showing the beginning of year and end of year rootworm egg numbers, which are analogous to the corn numbers.

Note also that `config` mode hides the bar charts when it shows the configuration panels. There may be a way to support both at some point (e.g. have the bar charts be a selectable panel in the MultiPanel), but this was simpler in the short term.

@dstrawberrygirl I'm going to go ahead and merge this and the other PRs in preparation for the meeting tomorrow, but feel free to add any review comments for future consideration.